### PR TITLE
1st Pull

### DIFF
--- a/giraph-core/src/main/java/org/apache/giraph/job/HadoopUtils.java
+++ b/giraph-core/src/main/java/org/apache/giraph/job/HadoopUtils.java
@@ -24,8 +24,8 @@ import org.apache.hadoop.mapreduce.TaskAttemptID;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 
 /*if_not[HADOOP_NON_JOBCONTEXT_IS_INTERFACE]*/
-import org.apache.hadoop.mapreduce.task.JobContextImpl;
-import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
+//import org.apache.hadoop.mapreduce.task.JobContextImpl;
+//import org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl;
 /*end[HADOOP_NON_JOBCONTEXT_IS_INTERFACE]*/
 
 /**
@@ -45,10 +45,10 @@ public class HadoopUtils {
   public static TaskAttemptContext makeTaskAttemptContext(Configuration conf,
       TaskAttemptID taskAttemptID) {
     TaskAttemptContext context;
-    /*if[HADOOP_NON_JOBCONTEXT_IS_INTERFACE]
+    //if[HADOOP_NON_JOBCONTEXT_IS_INTERFACE]
     context = new TaskAttemptContext(conf, taskAttemptID);
-    else[HADOOP_NON_JOBCONTEXT_IS_INTERFACE]*/
-    context = new TaskAttemptContextImpl(conf, taskAttemptID);
+    //else[HADOOP_NON_JOBCONTEXT_IS_INTERFACE]*/
+    //context = new TaskAttemptContextImpl(conf, taskAttemptID);
     /*end[HADOOP_NON_JOBCONTEXT_IS_INTERFACE]*/
     return context;
   }
@@ -93,10 +93,10 @@ public class HadoopUtils {
    */
   public static JobContext makeJobContext(Configuration conf, JobID jobID) {
     JobContext context;
-    /*if[HADOOP_NON_JOBCONTEXT_IS_INTERFACE]
+    //if[HADOOP_NON_JOBCONTEXT_IS_INTERFACE]
     context = new JobContext(conf, jobID);
-    else[HADOOP_NON_JOBCONTEXT_IS_INTERFACE]*/
-    context = new JobContextImpl(conf, jobID);
+    //else[HADOOP_NON_JOBCONTEXT_IS_INTERFACE]*/
+    //context = new JobContextImpl(conf, jobID);
     /*end[HADOOP_NON_JOBCONTEXT_IS_INTERFACE]*/
     return context;
   }

--- a/giraph-gora/src/test/java/org/apache/giraph/io/gora/GoraTestEdgeInputFormat.java
+++ b/giraph-gora/src/test/java/org/apache/giraph/io/gora/GoraTestEdgeInputFormat.java
@@ -88,7 +88,7 @@ public abstract class GoraTestEdgeInputFormat
   /** Data store used for querying data. */
   private static DataStore DATA_STORE;
 
-  /** counter for iinput records */
+  /** counter for input records */
   private static int RECORD_COUNTER = 0;
 
   /** Delegate Gora input format */

--- a/giraph-gora/src/test/java/org/apache/giraph/io/gora/TestGoraEdgeInputFormat.java
+++ b/giraph-gora/src/test/java/org/apache/giraph/io/gora/TestGoraEdgeInputFormat.java
@@ -85,9 +85,9 @@ public class TestGoraEdgeInputFormat extends AbstractTestGoraEdgeFormat{
         "org.apache.hadoop.io.serializer.WritableSerialization," +
         "org.apache.hadoop.io.serializer.JavaSerialization");
     conf.setComputationClass(EmptyComputation.class);
-    conf.setEdgeInputFormatClass(GoraTestEdgeInputFormat.class);
+    conf.setEdgeInputFormatClass(GoraGEdgeEdgeInputFormat.class);
     results = InternalVertexRunner.run(conf, new String[0], new String[0]);
-    Assert.assertNotNull(results);
+    Assert.assertNotNull("Results object is: " + results, results);
     if (results instanceof Collection<?>) {
       Assert.assertTrue((((Collection<?>)results).size())>=0);
     }

--- a/giraph-gora/src/test/java/org/apache/giraph/io/gora/TestGoraEdgeOutputFormat.java
+++ b/giraph-gora/src/test/java/org/apache/giraph/io/gora/TestGoraEdgeOutputFormat.java
@@ -27,7 +27,6 @@ import static org.apache.giraph.io.gora.constants.GiraphGoraConstants.GIRAPH_GOR
 import static org.apache.giraph.io.gora.constants.GiraphGoraConstants.GIRAPH_GORA_OUTPUT_KEY_CLASS;
 import static org.apache.giraph.io.gora.constants.GiraphGoraConstants.GIRAPH_GORA_OUTPUT_PERSISTENT_CLASS;
 
-import java.io.IOException;
 import java.util.Iterator;
 
 import org.apache.giraph.conf.GiraphConfiguration;

--- a/pom.xml
+++ b/pom.xml
@@ -1280,7 +1280,7 @@ under the License.
 
   <modules>
     <module>giraph-core</module>
-    <module>giraph-examples</module>
+    <!-- module>giraph-examples</module-->
   </modules>
 
 </project>


### PR DESCRIPTION
fix instantiation of abstract class from conf.setEdgeInputFormatClass(GoraEdgeInputFormat.class) to conf.setEdgeInputFormatClass(GoraGEdgeEdgeInputFormat.class) in TestGoraEdgeInputFormat#getTestDb

I think I am now getting this though mate

13/11/03 16:11:01 FATAL graph.GraphMapper: uncaughtException: OverrideExceptionHandler on thread org.apache.giraph.master.MasterThread, msg = Unresolved compilation problem: 
, exiting...
java.lang.Error: Unresolved compilation problem: 

```
at org.apache.giraph.job.HadoopUtils.makeJobContext(HadoopUtils.java:111)
at org.apache.giraph.io.internal.WrappedEdgeInputFormat.getSplits(WrappedEdgeInputFormat.java:71)
at org.apache.giraph.master.BspServiceMaster.generateInputSplits(BspServiceMaster.java:316)
at org.apache.giraph.master.BspServiceMaster.createInputSplits(BspServiceMaster.java:629)
at org.apache.giraph.master.BspServiceMaster.createEdgeInputSplits(BspServiceMaster.java:708)
at org.apache.giraph.master.MasterThread.run(MasterThread.java:103)
```

I'll have a look later on mate OK. 
ttyl
